### PR TITLE
Force the use of miniupnpc-2.2.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,7 @@ nixpkgs.callPackage ./elements.nix {
   inherit doCheck doFunctionalTests withBench withCoverage withFuzz withTests withWallet
           qaAssetsDir unitTestDataDir fuzzSeedCorpusDir;
   boost = nixpkgs.boost175;
+  miniupnpc = nixpkgs.callPackage ./miniupnpc-2.2.7.nix { };
   stdenv = nixpkgs.clangStdenv;
   ${if gitDir == null then null else "withSource"} = builtins.fetchGit gitDir;
 }

--- a/miniupnpc-2.2.7.nix
+++ b/miniupnpc-2.2.7.nix
@@ -1,0 +1,45 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "miniupnpc";
+  version = "2.2.7";
+
+  src = fetchFromGitHub {
+    owner = "miniupnp";
+    repo = "miniupnp";
+    rev = "miniupnpc_${lib.replaceStrings ["."] ["_"] version}";
+    hash = "sha256-cIijY1NcdF169tibfB13845UT9ZoJ/CZ+XLES9ctWTY=";
+  };
+
+  sourceRoot = "${src.name}/miniupnpc";
+
+  nativeBuildInputs = [ cmake ];
+
+  doCheck = !stdenv.isFreeBSD;
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    chmod +x $out/lib/libminiupnpc${stdenv.hostPlatform.extensions.sharedLibrary}
+
+    # for some reason cmake does not install binaries and manpages
+    # https://github.com/miniupnp/miniupnp/issues/637
+    mkdir -p $out/bin
+    cp -a upnpc-static $out/bin/upnpc
+    cp -a ../external-ip.sh $out/bin/external-ip
+    mkdir -p $out/share/man
+    cp -a ../man3 $out/share/man
+  '';
+
+  meta = with lib; {
+    homepage = "https://miniupnp.tuxfamily.org/";
+    description = "Client that implements the UPnP Internet Gateway Device (IGD) specification";
+    platforms = with platforms; linux ++ freebsd ++ darwin;
+    license = licenses.bsd3;
+    mainProgram = "upnpc";
+  };
+}


### PR DESCRIPTION
At least elements-22.x does not seem to build with miniupnpc-2.2.8. For now, we force the use of miniupnpc-2.2.7.

Later we can make some options for compiling with the latest miniupnpc.