### PR TITLE
Omnibus

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Build elements with coverage and run tests (both unit and functional) to produce
 
 Build the fuzzer binary for elements.  This binary can be used to create `qa-assets/fuzz_seed_corpus` similar to what is found in [qa-assets](https://github.com/ElementsProject/qa-assets).
 
-    [~/elements-nix]$ nix-build --arg withFuzz true
+    [~/elements-nix]$ nix-build --arg withFuzz \"full\"
 
 Build the fuzzer binary for elements and use the qa-assets to produce coverage analys
 
-    [~/elements-nix]$ nix-build --arg withFuzz true --arg withCoverage
+    [~/elements-nix]$ nix-build --arg withFuzz \"full\" --arg withCoverage
 
 ## Advanced Usage
 

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@
 , doCheck ? (doFunctionalTests || withCoverage)
 , withTests ? doCheck
 , withWallet ? true
+, withGCC13Patches ? false
 , gitDir ? null
 , qaAssetsDir ?
         nixpkgs.fetchFromGitHub {
@@ -24,7 +25,7 @@
 , fuzzSeedCorpusDir ? if qaAssetsDir != null then "${qaAssetsDir}/fuzz_seed_corpus" else null
 }:
 nixpkgs.callPackage ./elements.nix {
-  inherit doCheck doFunctionalTests withBench withCoverage withFuzz withTests withWallet
+  inherit doCheck doFunctionalTests withBench withCoverage withFuzz withTests withWallet withGCC13Patches
           qaAssetsDir unitTestDataDir fuzzSeedCorpusDir;
   miniupnpc = nixpkgs.callPackage ./miniupnpc-2.2.7.nix { };
   lcov = nixpkgs.callPackage ./lcov-1.16.nix { };

--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,6 @@
 nixpkgs.callPackage ./elements.nix {
   inherit doCheck doFunctionalTests withBench withCoverage withFuzz withTests withWallet
           qaAssetsDir unitTestDataDir fuzzSeedCorpusDir;
-  boost = nixpkgs.boost175;
   miniupnpc = nixpkgs.callPackage ./miniupnpc-2.2.7.nix { };
   lcov = nixpkgs.callPackage ./lcov-1.16.nix { };
   stdenv = nixpkgs.clangStdenv;

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 , withBench ? false
 , withDebug ? false
 , withCoverage ? false
-, withFuzz ? false
+, withFuzz ? "none" # alterantively a list of sanitizers, or an option for sanitizerMap below.
 , doCheck ? (doFunctionalTests || withCoverage)
 , withTests ? doCheck
 , withWallet ? true
@@ -25,9 +25,15 @@
 , unitTestDataDir ? if qaAssetsDir != null then "${qaAssetsDir}/unit_test_data" else null
 , fuzzSeedCorpusDir ? if qaAssetsDir != null then "${qaAssetsDir}/fuzz_seed_corpus" else null
 }:
+let sanitizerMap = {
+      none = [];
+      fast = ["fuzzer"];
+      full = ["address" "fuzzer" "undefined" "integer"];
+    }; in
 nixpkgs.callPackage ./elements.nix {
-  inherit doCheck doFunctionalTests withBench withCoverage withDebug withFuzz withTests withWallet withGCC13Patches
+  inherit doCheck doFunctionalTests withBench withCoverage withDebug withTests withWallet withGCC13Patches
           qaAssetsDir unitTestDataDir fuzzSeedCorpusDir;
+  sanitizers = if builtins.isString withFuzz then sanitizerMap.${withFuzz} else withFuzz;
   miniupnpc = nixpkgs.callPackage ./miniupnpc-2.2.7.nix { };
   lcov = nixpkgs.callPackage ./lcov-1.16.nix { };
   stdenv = nixpkgs.clangStdenv;

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { nixpkgs ? import <nixpkgs> {}
 , doFunctionalTests ? false
 , withBench ? false
+, withDebug ? false
 , withCoverage ? false
 , withFuzz ? false
 , doCheck ? (doFunctionalTests || withCoverage)
@@ -25,7 +26,7 @@
 , fuzzSeedCorpusDir ? if qaAssetsDir != null then "${qaAssetsDir}/fuzz_seed_corpus" else null
 }:
 nixpkgs.callPackage ./elements.nix {
-  inherit doCheck doFunctionalTests withBench withCoverage withFuzz withTests withWallet withGCC13Patches
+  inherit doCheck doFunctionalTests withBench withCoverage withDebug withFuzz withTests withWallet withGCC13Patches
           qaAssetsDir unitTestDataDir fuzzSeedCorpusDir;
   miniupnpc = nixpkgs.callPackage ./miniupnpc-2.2.7.nix { };
   lcov = nixpkgs.callPackage ./lcov-1.16.nix { };

--- a/elements-lcov.patch
+++ b/elements-lcov.patch
@@ -1,0 +1,11 @@
+--- elements/Makefile.am
++++ elements/Makefile.am
+@@ -188,6 +188,8 @@
+ 	-p "/usr/include/" \
+ 	-p "/usr/lib/" \
+ 	-p "/usr/lib64/" \
++	-p "/nix/store/" \
++	-p "src/include/boost/" \
+ 	-p "src/leveldb/" \
+ 	-p "src/crc32c/" \
+ 	-p "src/bench/" \

--- a/elements.nix
+++ b/elements.nix
@@ -1,5 +1,5 @@
 args@
-{ stdenv, fetchFromGitHub ? null, pkg-config, autoreconfHook, db48, boost, zeromq
+{ stdenv, fetchFromGitHub ? null, fetchpatch, pkg-config, autoreconfHook, db48, boost, zeromq
 , zlib, miniupnpc, qtbase ? null, qttools ? null, util-linux ? null, hexdump ? null, protobuf, python3, qrencode, libevent
 , lcov ? null
 , lib, writeText
@@ -14,6 +14,7 @@ args@
 , qaAssetsDir ? null
 , unitTestDataDir ? if qaAssetsDir != null then "${qaAssetsDir}/unit_test_data" else null
 , fuzzSeedCorpusDir ? if qaAssetsDir != null then "${qaAssetsDir}/fuzz_seed_corpus" else null
+, withGCC13Patches ? false
 }:
 
 assert withFuzz -> stdenv.cc.isClang;
@@ -33,7 +34,19 @@ stdenv.mkDerivation rec {
           sha256 = "sha256-UNjYkEZBjGuhkwBxSkNXjBBcLQqoan/afCLhoR2lOY4=";
         };
 
-  patches = [ ./elements-lcov.patch ];
+  patches = optionals withCoverage [ ./elements-lcov.patch ]
+         ++ optionals withGCC13Patches [
+              (fetchpatch {
+                name = "Add-missing-includes-to-fix-gcc-13-compile-error.patch";
+                url = "https://github.com/bitcoin/bitcoin/commit/398768769f85cc1b6ff212ed931646b59fa1acd6.patch";
+                hash = "sha256-4nnE4W0Z5HzVaJ6tB8QmyohXmt6UHUGgDH+s9bQaxhg=";
+              })
+              (fetchpatch {
+                name = "23-x-Add-missing-includes-to-fix-gcc-13-compile-error.patch";
+                url = "https://github.com/bitcoin/bitcoin/commit/af862661654966d5de614755ab9bd1b5913e0959.patch";
+                hash = "sha256-4hcJIje3VAdEEpn2tetgvgZ8nVft+A64bfWLspQtbVw=";
+              })
+            ];
 
   postPatch = optionals (doCheck)
   ''

--- a/elements.nix
+++ b/elements.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation rec {
     patchShebangs contrib/filter-lcov.py
     patchShebangs test/functional
     patchShebangs test/fuzz
+    substituteInPlace test/sanitizer_suppressions/ubsan --replace "*/include/" "include/"
   '';
 
   nativeBuildInputs = [ pkg-config autoreconfHook ]

--- a/elements.nix
+++ b/elements.nix
@@ -7,6 +7,7 @@ args@
 , withBench ? false
 , withWallet ? true
 , withCoverage ? false
+, withDebug ? false
 , withFuzz ? false
 , doCheck ? (doFunctionalTests || withCoverage)
 , withTests ? doCheck
@@ -68,6 +69,8 @@ stdenv.mkDerivation rec {
                      "--with-boost=${boost.dev}"
                    ] ++ optionals (withCoverage) [
                      "--enable-lcov --enable-lcov-branch-coverage"
+                   ] ++ optionals (withDebug) [
+                     "--enable-debug"
                    ] ++ optionals (withFuzz) [
                      "--enable-fuzz --with-sanitizers=address,fuzzer,undefined"
                    ] ++ optionals (!withBench) [

--- a/elements.nix
+++ b/elements.nix
@@ -33,6 +33,8 @@ stdenv.mkDerivation rec {
           sha256 = "sha256-UNjYkEZBjGuhkwBxSkNXjBBcLQqoan/afCLhoR2lOY4=";
         };
 
+  patches = [ ./elements-lcov.patch ];
+
   postPatch = optionals (doCheck)
   ''
     patchShebangs contrib/filter-lcov.py

--- a/elements.nix
+++ b/elements.nix
@@ -8,7 +8,8 @@ args@
 , withWallet ? true
 , withCoverage ? false
 , withDebug ? false
-, withFuzz ? false
+, sanitizers ? []
+, withFuzz ? lib.elem "fuzzer" sanitizers
 , doCheck ? (doFunctionalTests || withCoverage)
 , withTests ? doCheck
 , doFunctionalTests ? true
@@ -21,8 +22,8 @@ args@
 assert withFuzz -> stdenv.cc.isClang;
 assert withCoverage -> stdenv.cc.isClang;
 assert doCheck -> withTests;
-let withAssets = doCheck && (withCoverage || doFunctionalTests); in
 with lib;
+let withAssets = doCheck && (withCoverage || doFunctionalTests); in
 stdenv.mkDerivation rec {
   pname = "elements";
   version = if withSource == null then "23.2.4" else "custom";
@@ -72,7 +73,9 @@ stdenv.mkDerivation rec {
                    ] ++ optionals (withDebug) [
                      "--enable-debug"
                    ] ++ optionals (withFuzz) [
-                     "--enable-fuzz --with-sanitizers=address,fuzzer,undefined"
+                     "--enable-fuzz"
+                   ] ++ optionals ([] != sanitizers) [
+                     "--with-sanitizers=${concatStringsSep "," sanitizers}"
                    ] ++ optionals (!withBench) [
                      "--disable-bench"
                    ] ++ optionals (!withWallet) [


### PR DESCRIPTION
Remove boost and /nix/store stuff from the coverage report.

I think there is a better way of fixing the boost stuf using
geninfo_adjust_src_path, but I couldn't get it to work.